### PR TITLE
Added exec_query to read only method list. Looks like only place used…

### DIFF
--- a/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb
+++ b/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb
@@ -89,7 +89,7 @@ module ActiveRecord
           return const_get(adapter_class_name) if const_defined?(adapter_class_name, false)
           
           # Define methods to proxy to the appropriate pool
-          read_only_methods = [:select, :select_rows, :execute, :tables, :columns]
+          read_only_methods = [:select, :select_rows, :execute, :tables, :columns, :exec_query]
           clear_cache_methods = [:insert, :update, :delete]
           
           # Get a list of all methods redefined by the underlying adapter. These will be


### PR DESCRIPTION
… in ActiveRecord 3.2 is in :pluck which is read only. Adding exec_query function to the list of read only methods so methods uses .pluck(:id) etc will use the configured pool instead of alwasy the master pool.